### PR TITLE
attack 기능 구현

### DIFF
--- a/BattleInfo/BattleInfo.cpp
+++ b/BattleInfo/BattleInfo.cpp
@@ -3,3 +3,10 @@
 //
 
 #include "BattleInfo.hpp"
+
+void BattleInfo::Reset() {
+    hp_ = max_hp_;
+    attack_ = ATTACK;
+    defense_ = DEFENSE;
+    position_x_ = POSITION_X;
+}

--- a/BattleInfo/BattleInfo.hpp
+++ b/BattleInfo/BattleInfo.hpp
@@ -6,20 +6,22 @@
 #define LOBBYSERVER_BATTLEINFO_HPP
 
 class BattleInfo {
+  static const short MAX_HP = 100;
+  static const short ATTACK = 15;
+  static const short DEFENSE = 5;
+  static const short POSITION_X = 0;
+
  public:
-  short max_hp_ = 100;
+  short max_hp_ = MAX_HP;
   short hp_ = max_hp_;
-  short attack_ = 15;
-  short defense_ = 5;
-  short position_x_ = 0; // FIXME: 이동 로직 구현
+  short attack_ = ATTACK;
+  short defense_ = DEFENSE;
+  short position_x_ = POSITION_X; // FIXME: 이동 기능
 
  public:
   BattleInfo() = default;
   ~BattleInfo() = default;
-
-
-
-
+  void Reset();
 };
 
 #endif  //LOBBYSERVER_BATTLEINFO_HPP

--- a/BattleInfo/BattleManager.cpp
+++ b/BattleInfo/BattleManager.cpp
@@ -4,6 +4,7 @@
 
 #include "BattleManager.hpp"
 #include "BattleInfo.hpp"
+#include "../server/Session.hpp"
 
 void BattleManager::Attack(std::shared_ptr<BattleInfo> attacker,
                            std::shared_ptr<BattleInfo> defender) {
@@ -18,6 +19,23 @@ void BattleManager::Attack(std::shared_ptr<BattleInfo> attacker,
     }
 
     if (defender->hp_ == 0) {
-        // FIXME: 사망 로직
+
+    }
+}
+
+void BattleManager::Attack(std::shared_ptr<Session> attacker,
+                           std::shared_ptr<Session> defender) {
+    short damage = attacker->battleInfo_->attack_ - defender->battleInfo_->defense_;
+    if (damage < 0) {
+        damage = 0;
+    }
+
+    defender->battleInfo_->hp_ -= damage;
+    if (defender->battleInfo_->hp_ < 0) {
+        defender->battleInfo_->hp_ = 0;
+    }
+
+    if (defender->battleInfo_->hp_ == 0) {
+      defender->state_ = USER_STATE::DIED;
     }
 }

--- a/BattleInfo/BattleManager.hpp
+++ b/BattleInfo/BattleManager.hpp
@@ -16,6 +16,7 @@ class BattleManager {
     ~BattleManager() = default;
 
     void Attack(std::shared_ptr<BattleInfo> attacker, std::shared_ptr<BattleInfo> defender);
+    void Attack(std::shared_ptr<Session> attacker, std::shared_ptr<Session> defender);
 //    void Move();
 };
 

--- a/Packet/Packet.hpp
+++ b/Packet/Packet.hpp
@@ -44,6 +44,7 @@ enum class PACKET_ID : uint16_t {
   ATTACK_REQUEST = 221,
   ATTACK_RESPONSE = 222,
 
+  BATTLE_INFO = 223,
 };
 
 #pragma pack(push, 1)
@@ -285,6 +286,16 @@ struct ATTACK_RESPONSE_PACKET : public PACKET_HEADER {
   }
 
   BATTLE_INFO battleInfos[2]{}; // FIXME: 2명만 전투 가능
+  uint16_t result{};
+};
+
+struct BATTLE_INFO_PACKET : public PACKET_HEADER {
+  BATTLE_INFO_PACKET() : PACKET_HEADER() {
+    PacketId = static_cast<uint16_t>(PACKET_ID::BATTLE_INFO);
+    PacketLength = sizeof(BATTLE_INFO_PACKET);
+  }
+
+  BATTLE_INFO battleInfos[2]{};
   uint16_t result{};
 };
 

--- a/client/Client.h
+++ b/client/Client.h
@@ -37,10 +37,11 @@ class Client {
   shared_ptr<boost::asio::io_service::work> work_;
   thread_group thread_group_;
   std::string writeBuffer_;
-  std::string readBuffer_;
   std::array<char, 1000> buffer_;
+  boost::asio::posix::stream_descriptor input_;
   std::mutex lock_;
   boost::asio::steady_timer timer_;
+  std::atomic<bool> is_get_input_ = true;
 
  public:
   USER_STATE state_ = USER_STATE::NONE;
@@ -60,6 +61,8 @@ class Client {
   void Send();
 
   void Receive();
+
+  void InputHandler(const system::error_code& error, std::size_t bytes_transferred);
 
   void SendHandle(const system::error_code& ec, const char* packet);
 
@@ -95,7 +98,7 @@ class Client {
 
   void ResponseAttack(ATTACK_RESPONSE_PACKET packet);
 
-  void RequestAttack();
+  void ResponseBattleInfo(BATTLE_INFO_PACKET packet);
 };
 
 #endif  //BOOSTASIO_CLIENT_H

--- a/client/ClientPacketManager.cpp
+++ b/client/ClientPacketManager.cpp
@@ -240,4 +240,10 @@ void ClientPacketManager::ReceivePacket(Client* client, char* pBuf,
     client->ResponseAttack(*packet);
     return;
   }
+
+  if (packetId == PACKET_ID::BATTLE_INFO) {
+    auto packet = reinterpret_cast<BATTLE_INFO_PACKET*>(pBuf);
+    client->ResponseBattleInfo(*packet);
+    return;
+  }
 }

--- a/server/Room.hpp
+++ b/server/Room.hpp
@@ -12,7 +12,7 @@ class BattleManager;
 
 class Room : public std::enable_shared_from_this<Room> {
   Lobby* lobby_;
-  std::vector<Session::pointer> clients_;
+  std::list<Session::pointer> clients_;
   Session::pointer owner_;
   static int ID_COUNTER;
   static const int MAX_CLIENT_SIZE = 2; // FIXME: 임시로 2명으로 설정
@@ -27,14 +27,17 @@ class Room : public std::enable_shared_from_this<Room> {
   void Broadcast(char* packet, uint16_t copySize, Session::pointer sender, bool isExceptMe = true);
   // overloading bool function type
   void Broadcast(char* packet, uint16_t copySize, Session::pointer sender, std::function<bool(Session*)> condition, bool isExceptMe = true);
+
   int Enter(Session::pointer session);
   int Leave(Session::pointer session);
   bool IsOwner(Session::pointer session);
   bool IsReady();
   void BattleStart();
+  bool IsBattleEnd();
+  void BattleEnd();
   int GetClientSize();
   void Attack(Session::pointer session);
-  std::vector<std::shared_ptr<Session>> GetClients();
+  std::list<std::shared_ptr<Session>> GetClients();
 };
 
 #endif  //LOBBYSERVER_ROOM_HPP

--- a/server/Session.hpp
+++ b/server/Session.hpp
@@ -25,13 +25,11 @@ enum class USER_STATE : uint16_t {
   ROOM = 2,
   READY = 3,
   BATTLE = 4,
+  DIED = 5,
 };
 
 class Session : public std::enable_shared_from_this<Session> {
   static int ID_COUNTER;
-  USER_STATE state_ = USER_STATE::NONE;
-
-
  public:
   using pointer = std::shared_ptr<Session>;
 
@@ -40,6 +38,8 @@ class Session : public std::enable_shared_from_this<Session> {
 
   const int id_ = ID_COUNTER;
   string name_;
+  USER_STATE state_ = USER_STATE::NONE;
+
   string readBuffer;
   std::array<char, 240> buffer_;
   std::shared_ptr<BattleInfo> battleInfo_;


### PR DESCRIPTION
## 배틀 시작과 공격 기능 구현
- 배틀 시작 시, 각 클라이언트는 1초마다 Attack 패킷을 송신
- 해당 패킷에 대한 응답으로 전투 상황을 수신
- 1명의 클라이언트의 hp가 0이 되면 배틀을 종료

[콘솔 블로킹](https://www.notion.so/non-blocking-482db3eff26f4a23bb9a83676337997e)
콘솔 입력의 블로킹으로 인해, 배틀 응답 패킷이 출력되지 않았던 이슈를 정리했습니다!

#### 부족한 점
- Room의 정원을 4명에서 2명으로 줄여서 진행했습니다. (공격 매커니즘을 단순화하기 위해 우선 줄였습니다..!)
- battle 중엔 콘솔 입력이 안됩니다
- 에러 핸들링이 제대로 되지 않은 부분이 있습니다..!
- 배틀 내용을 단순히 출력만 합니다
- 코드가 좀.. 엉망입니다 ㅎㅎ..